### PR TITLE
Backwards compatibility update

### DIFF
--- a/include/hecate/gapstat.hpp
+++ b/include/hecate/gapstat.hpp
@@ -24,6 +24,11 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
+#if CV_MAJOR_VERSION > 2
+#include <opencv2/core/core_c.h>
+#include <opencv2/imgproc/types_c.h>
+#endif
+
 using namespace std;
 using namespace cv;
 

--- a/include/hecate/gflseg.hpp
+++ b/include/hecate/gflseg.hpp
@@ -20,6 +20,10 @@
 #include <opencv2/opencv.hpp>
 #include <opencv2/core/core.hpp>
 
+#if CV_MAJOR_VERSION > 2
+#include <opencv2/core/core_c.h>
+#endif
+
 #include "hecate/sort.hpp"
 
 using namespace std;

--- a/include/hecate/hist_opencv.hpp
+++ b/include/hecate/hist_opencv.hpp
@@ -14,6 +14,10 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
+#if CV_MAJOR_VERSION > 2
+#include <opencv2/imgproc/types_c.h>
+#endif
+
 using namespace cv;
 using namespace std;
 

--- a/include/hecate/video_parser.hpp
+++ b/include/hecate/video_parser.hpp
@@ -39,6 +39,10 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
+#if CV_MAJOR_VERSION > 3
+#include <opencv2/videoio/legacy/constants_c.h>
+#endif
+
 #include "hecate/sort.hpp"
 #include "hecate/gflseg.hpp"
 #include "hecate/gapstat.hpp"


### PR DESCRIPTION
It appears opencv has header files that define the old constants for backward compatibility, I've added optional includes for those. I tested compiling against version 3.4 and 4.4 and that worked fine, and given how simple the change is I figure it should also work for 2.4.

Wasn't that big of a hassle, and should hopefully work smoothly for all versions now.

Small thing is that even when compiling against version 4, the Makefile.config should still have OPENCV_VERSION at 3, but as it says to only comment when using 2.4 I figure that doesnt have to change.
